### PR TITLE
Move construction of PoseRelativeToGraph and FrameAttachedToGraph to sdf::Root

### DIFF
--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -301,15 +301,17 @@ namespace sdf
     public: void SetPlacementFrameName(const std::string &_name);
 
     /// \brief Give the Scoped PoseRelativeToGraph to be used for resolving
-    /// poses. This is private and is intended to be called by World::Load and
-    /// Model::Load if this is a nested model.
+    /// poses. This is private and is intended to be called by Root::Load or
+    /// World::SetPoseRelativeToGraph if this is a standalone model and
+    /// Model::SetPoseRelativeToGraph if this is a nested model.
     /// \param[in] _graph Scoped PoseRelativeToGraph object.
     private: void SetPoseRelativeToGraph(
         sdf::ScopedGraph<PoseRelativeToGraph> _graph);
 
     /// \brief Give the Scoped FrameAttachedToGraph to be used for resolving
     /// attached bodies. This is private and is intended to be called by
-    /// World::Load and Model::Load if this is a nested model.
+    /// Root::Load or World::SetFrameAttachedToGraph if this is a standalone
+    /// model and Model::SetFrameAttachedToGraph if this is a nested model.
     /// \param[in] _graph Scoped FrameAttachedToGraph object.
     private: void SetFrameAttachedToGraph(
         sdf::ScopedGraph<FrameAttachedToGraph> _graph);
@@ -321,8 +323,10 @@ namespace sdf
     private: std::pair<const Link *, std::string> CanonicalLinkAndRelativeName()
         const;
 
-    /// \brief Allow World::Load to call SetPoseRelativeToGraph and
+    /// \brief Allow Root::Load, World::SetPoseRelativeToGraph, or
+    /// World::SetFrameAttachedToGraph to call SetPoseRelativeToGraph and
     /// SetFrameAttachedToGraph
+    friend class Root;
     friend class World;
 
     /// \brief Allow helper function in FrameSemantics.cc to call

--- a/include/sdf/Root.hh
+++ b/include/sdf/Root.hh
@@ -56,6 +56,24 @@ namespace sdf
     /// \brief Default constructor
     public: Root();
 
+    /// \brief Copy constructor
+    /// \param[in] _root Root to copy.
+    public: Root(const Root &_root);
+
+    /// \brief Move constructor
+    /// \param[in] _root Root to move.
+    public: Root(Root &&_root) noexcept;
+
+    /// \brief Move assignment operator.
+    /// \param[in] _root Root to move.
+    /// \return Reference to this.
+    public: Root &operator=(Root &&_root) noexcept;
+
+    /// \brief Copy assignment operator.
+    /// \param[in] _root Root to copy.
+    /// \return Reference to this.
+    public: Root &operator=(const Root &_root);
+
     /// \brief Destructor
     public: ~Root();
 

--- a/include/sdf/Root.hh
+++ b/include/sdf/Root.hh
@@ -56,9 +56,9 @@ namespace sdf
     /// \brief Default constructor
     public: Root();
 
-    /// \brief Copy constructor
-    /// \param[in] _root Root to copy.
-    public: Root(const Root &_root);
+    /// \brief Copy constructor is explicitly deleted to avoid copying the
+    /// FrameAttachedToGraph and PoseRelativeToGraphs contained in Root.
+    public: Root(const Root &_root) = delete;
 
     /// \brief Move constructor
     /// \param[in] _root Root to move.
@@ -69,10 +69,9 @@ namespace sdf
     /// \return Reference to this.
     public: Root &operator=(Root &&_root) noexcept;
 
-    /// \brief Copy assignment operator.
-    /// \param[in] _root Root to copy.
-    /// \return Reference to this.
-    public: Root &operator=(const Root &_root);
+    /// \brief Copy assignment operator is explicitly deleted to avoid copying
+    /// the FrameAttachedToGraph and PoseRelativeToGraphs contained in Root.
+    public: Root &operator=(const Root &_root) = delete;
 
     /// \brief Destructor
     public: ~Root();

--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -41,6 +41,9 @@ namespace sdf
   class Model;
   class Physics;
   class WorldPrivate;
+  struct PoseRelativeToGraph;
+  struct FrameAttachedToGraph;
+  template <typename T> class ScopedGraph;
 
   class SDFORMAT_VISIBLE World
   {
@@ -268,6 +271,24 @@ namespace sdf
     /// \param[in] _name Name of the physics profile to check.
     /// \return True if there exists a physics profile with the given name.
     public: bool PhysicsNameExists(const std::string &_name) const;
+
+    /// \brief Give the Scoped PoseRelativeToGraph to be passed on to child
+    /// entities for resolving poses. This is private and is intended to be
+    /// called by Root::Load.
+    /// \param[in] _graph Scoped PoseRelativeToGraph object.
+    private: void SetPoseRelativeToGraph(
+        sdf::ScopedGraph<PoseRelativeToGraph> _graph);
+
+    /// \brief Give the Scoped FrameAttachedToGraph to be passed on to child
+    /// entities for attached bodes. This is private and is intended to be
+    /// called by Root::Load.
+    /// \param[in] _graph Scoped FrameAttachedToGraph object.
+    private: void SetFrameAttachedToGraph(
+        sdf::ScopedGraph<FrameAttachedToGraph> _graph);
+
+    /// \brief Allow Root::Load to call SetPoseRelativeToGraph and
+    /// SetFrameAttachedToGraph
+    friend class Root;
 
     /// \brief Private data pointer.
     private: WorldPrivate *dataPtr = nullptr;

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -105,24 +105,6 @@ Model::~Model()
 Model::Model(const Model &_model)
   : dataPtr(new ModelPrivate(*_model.dataPtr))
 {
-  for (auto &link : this->dataPtr->links)
-  {
-    link.SetPoseRelativeToGraph(this->dataPtr->poseGraph);
-  }
-  for (auto &model : this->dataPtr->models)
-  {
-    model.SetPoseRelativeToGraph(this->dataPtr->poseGraph);
-  }
-  for (auto &joint : this->dataPtr->joints)
-  {
-    joint.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
-    joint.SetPoseRelativeToGraph(this->dataPtr->poseGraph);
-  }
-  for (auto &frame : this->dataPtr->frames)
-  {
-    frame.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
-    frame.SetPoseRelativeToGraph(this->dataPtr->poseGraph);
-  }
 }
 
 /////////////////////////////////////////////////

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -78,22 +78,10 @@ class sdf::ModelPrivate
   /// \brief The SDF element pointer used during load.
   public: sdf::ElementPtr sdf;
 
-  /// \brief Frame Attached-To Graph constructed during Load.
-  /// This would only be allocated if this model is a top level model, i.e, a
-  /// model file.
-  public: std::shared_ptr<sdf::FrameAttachedToGraph> ownedFrameAttachedToGraph;
-
-  /// \brief Scoped Frame Attached-To graph that can either point to a graph
-  /// owned by this model or a subgraph of a parent entity.
+  /// \brief Scoped Frame Attached-To graph at the parent model or world scope.
   public: sdf::ScopedGraph<sdf::FrameAttachedToGraph> frameAttachedToGraph;
 
-  /// \brief Pose Relative-To Graph constructed during Load.
-  /// This would only be allocated if this model is a top level model, i.e, a
-  /// model file.
-  public: std::shared_ptr<sdf::PoseRelativeToGraph> ownedPoseGraph;
-
-  /// \brief Scoped Pose Relative-To graph that can either point to a graph
-  /// owned by this model or a subgraph of a parent entity.
+  /// \brief Scoped Pose Relative-To graph at the parent model or world scope.
   public: sdf::ScopedGraph<sdf::PoseRelativeToGraph> poseGraph;
 
   /// \brief Scope name of parent Pose Relative-To Graph (world or __model__).
@@ -117,25 +105,6 @@ Model::~Model()
 Model::Model(const Model &_model)
   : dataPtr(new ModelPrivate(*_model.dataPtr))
 {
-  if (_model.dataPtr->ownedFrameAttachedToGraph)
-  {
-    // If the model owns the frameAttachedToGraph, we need to allocate a new
-    // sdf::FrameAttachedToGraph object and copy it. We also need to assign the
-    // ScopedGraph to this object
-    this->dataPtr->ownedFrameAttachedToGraph =
-        std::make_shared<sdf::FrameAttachedToGraph>(
-            *_model.dataPtr->ownedFrameAttachedToGraph);
-    this->dataPtr->frameAttachedToGraph =
-        ScopedGraph<sdf::FrameAttachedToGraph>(
-            this->dataPtr->ownedFrameAttachedToGraph);
-  }
-  if (_model.dataPtr->ownedPoseGraph)
-  {
-    this->dataPtr->ownedPoseGraph = std::make_shared<sdf::PoseRelativeToGraph>(
-        *_model.dataPtr->ownedPoseGraph);
-    this->dataPtr->poseGraph =
-        ScopedGraph<sdf::PoseRelativeToGraph>(this->dataPtr->ownedPoseGraph);
-  }
   for (auto &link : this->dataPtr->links)
   {
     link.SetPoseRelativeToGraph(this->dataPtr->poseGraph);
@@ -237,22 +206,6 @@ Errors Model::Load(ElementPtr _sdf)
   {
     sdfwarn << "Non-unique names detected in XML children of model with name["
             << this->Name() << "].\n";
-  }
-
-  // Whether this model is defined at the root level of an SDFormat file (i.e
-  // in XPath "/sdf/model")
-  bool isModelAtRootOfXmlFile = false;
-
-  auto parentElem = this->dataPtr->sdf->GetParent();
-  if (parentElem && parentElem->GetName() == "sdf")
-  {
-    this->dataPtr->ownedPoseGraph = std::make_shared<PoseRelativeToGraph>();
-    this->dataPtr->poseGraph = ScopedGraph(this->dataPtr->ownedPoseGraph);
-    this->dataPtr->ownedFrameAttachedToGraph =
-        std::make_shared<FrameAttachedToGraph>();
-    this->dataPtr->frameAttachedToGraph =
-        ScopedGraph(this->dataPtr->ownedFrameAttachedToGraph);
-    isModelAtRootOfXmlFile = true;
   }
 
   // Set of implicit and explicit frame names in this model for tracking
@@ -393,42 +346,6 @@ Errors Model::Load(ElementPtr _sdf)
       }
     }
     frameNames.insert(frameName);
-  }
-
-  // Build the graphs.
-
-  // Build the FrameAttachedToGraph if the model is not static.
-  // Re-enable this when the buildFrameAttachedToGraph implementation handles
-  // static models.
-  if (!this->Static())
-  {
-    if (isModelAtRootOfXmlFile)
-    {
-      Errors frameAttachedToGraphErrors =
-        buildFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph, this);
-      errors.insert(errors.end(), frameAttachedToGraphErrors.begin(),
-          frameAttachedToGraphErrors.end());
-      Errors validateFrameAttachedGraphErrors =
-          validateFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
-      errors.insert(errors.end(), validateFrameAttachedGraphErrors.begin(),
-          validateFrameAttachedGraphErrors.end());
-
-      this->SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
-    }
-  }
-
-  // Build the PoseRelativeToGraph
-  if (isModelAtRootOfXmlFile)
-  {
-    Errors poseGraphErrors =
-        buildPoseRelativeToGraph(this->dataPtr->poseGraph, this);
-    errors.insert(errors.end(), poseGraphErrors.begin(), poseGraphErrors.end());
-    Errors validatePoseGraphErrors =
-        validatePoseRelativeToGraph(this->dataPtr->poseGraph);
-    errors.insert(errors.end(), validatePoseGraphErrors.begin(),
-        validatePoseGraphErrors.end());
-
-    this->SetPoseRelativeToGraph(this->dataPtr->poseGraph);
   }
 
 
@@ -749,13 +666,6 @@ void Model::SetPoseRelativeTo(const std::string &_frame)
 /////////////////////////////////////////////////
 void Model::SetPoseRelativeToGraph(sdf::ScopedGraph<PoseRelativeToGraph> _graph)
 {
-  // If the scoped graph doesn't point to the graph owned by this model, we
-  // clear the owned graph to maintain the invariant that if
-  // ownedPoseGraph is valid poseGraph points to it.
-  if (!_graph.PointsTo(this->dataPtr->ownedPoseGraph))
-  {
-    this->dataPtr->ownedPoseGraph.reset();
-  }
   this->dataPtr->poseGraph = _graph;
   this->dataPtr->poseGraphScopeVertexName =
       _graph.VertexLocalName(_graph.ScopeVertexId());
@@ -784,14 +694,6 @@ void Model::SetPoseRelativeToGraph(sdf::ScopedGraph<PoseRelativeToGraph> _graph)
 void Model::SetFrameAttachedToGraph(
     sdf::ScopedGraph<FrameAttachedToGraph> _graph)
 {
-  // If the scoped graph doesn't point to the graph owned by this model, we
-  // clear the owned graph to maintain the invariant that if
-  // ownedFrameAttachedToGraph is valid frameAttachedToGraph points to it.
-  if (!_graph.PointsTo(this->dataPtr->ownedFrameAttachedToGraph))
-  {
-    this->dataPtr->ownedFrameAttachedToGraph.reset();
-  }
-
   this->dataPtr->frameAttachedToGraph = _graph;
 
   auto childFrameAttachedToGraph =

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -114,44 +114,9 @@ Root::Root()
 }
 
 /////////////////////////////////////////////////
-Root::Root(const Root &_root)
-  : dataPtr(new RootPrivate(*_root.dataPtr))
-{
-  // TODO(addisu) Do we need to make deep copies of the graphs?
-  //
-  // By construction the sizes of the worlds vector, the
-  // worldFrameAttachedToGraphs vector and the worldPoseRelativeToGraphs vector
-  // should be the same.
-  for (std::size_t i = 0; i < this->dataPtr->worlds.size(); ++i)
-  {
-    this->dataPtr->worlds[i].SetFrameAttachedToGraph(
-        this->dataPtr->worldFrameAttachedToGraphs[i]);
-    this->dataPtr->worlds[i].SetPoseRelativeToGraph(
-        this->dataPtr->worldPoseRelativeToGraphs[i]);
-  }
-
-  // By construction the sizes of the models vector, the
-  // modelFrameAttachedToGraphs vector and the modelPoseRelativeToGraphs vector
-  // should be the same.
-  for (std::size_t i = 0; i < this->dataPtr->models.size(); ++i)
-  {
-    this->dataPtr->models[i].SetFrameAttachedToGraph(
-        this->dataPtr->modelFrameAttachedToGraphs[i]);
-    this->dataPtr->models[i].SetPoseRelativeToGraph(
-        this->dataPtr->modelPoseRelativeToGraphs[i]);
-  }
-}
-
-/////////////////////////////////////////////////
 Root::Root(Root &&_root) noexcept
   : dataPtr(std::exchange(_root.dataPtr, nullptr))
 {
-}
-
-/////////////////////////////////////////////////
-Root &Root::operator=(const Root &_root)
-{
-  return *this = Root(_root);
 }
 
 /////////////////////////////////////////////////

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -91,7 +91,7 @@ sdf::ScopedGraph<FrameAttachedToGraph> addFrameAttachedToGraph(
 
 /////////////////////////////////////////////////
 template <typename T>
-ScopedGraph<PoseRelativeToGraph> addPoseRealtiveToGraph(
+ScopedGraph<PoseRelativeToGraph> addPoseRelativeToGraph(
     std::vector<sdf::ScopedGraph<sdf::PoseRelativeToGraph>> &_graphList,
     const T &_domObj, Errors &_errors)
 {
@@ -260,7 +260,7 @@ Errors Root::Load(SDFPtr _sdf)
           this->dataPtr->worldFrameAttachedToGraphs, world, worldErrors);
       world.SetFrameAttachedToGraph(frameAttachedToGraph);
 
-      auto poseRelativeToGraph = addPoseRealtiveToGraph(
+      auto poseRelativeToGraph = addPoseRelativeToGraph(
           this->dataPtr->worldPoseRelativeToGraphs, world, worldErrors);
       world.SetPoseRelativeToGraph(poseRelativeToGraph);
 
@@ -301,7 +301,7 @@ Errors Root::Load(SDFPtr _sdf)
 
     model.SetFrameAttachedToGraph(frameAttachedToGraph);
 
-    auto poseRelativeToGraph = addPoseRealtiveToGraph(
+    auto poseRelativeToGraph = addPoseRelativeToGraph(
         this->dataPtr->modelPoseRelativeToGraphs, model, errors);
     model.SetPoseRelativeToGraph(poseRelativeToGraph);
   }

--- a/src/Root_TEST.cc
+++ b/src/Root_TEST.cc
@@ -59,33 +59,12 @@ TEST(DOMRoot, Construction)
 }
 
 /////////////////////////////////////////////////
-TEST(DOMRoot, CopyConstructor)
-{
-  sdf::Root root;
-  root.SetVersion("test_root");
-
-  sdf::Root root2(root);
-  EXPECT_EQ("test_root", root2.Version());
-}
-
-/////////////////////////////////////////////////
-TEST(DOMRoot, CopyAssignmentOperator)
-{
-  sdf::Root root;
-  root.SetVersion("test_root");
-
-  sdf::Root root2;
-  root2 = root;
-  EXPECT_EQ("test_root", root2.Version());
-}
-
-/////////////////////////////////////////////////
 TEST(DOMRoot, MoveConstructor)
 {
   sdf::Root root;
   root.SetVersion("test_root");
 
-  sdf::Root root2(root);
+  sdf::Root root2(std::move(root));
   EXPECT_EQ("test_root", root2.Version());
 }
 
@@ -98,25 +77,6 @@ TEST(DOMRoot, MoveAssignmentOperator)
   sdf::Root root2;
   root2 = std::move(root);
   EXPECT_EQ("test_root", root2.Version());
-}
-
-/////////////////////////////////////////////////
-TEST(DOMRoot, CopyAssignmentAfterMove)
-{
-  sdf::Root root1;
-  root1.SetVersion("root1");
-
-  sdf::Root root2;
-  root2.SetVersion("root2");
-
-  // This is similar to what std::swap does except it uses std::move for each
-  // assignment
-  sdf::Root tmp = std::move(root1);
-  root1 = root2;
-  root2 = tmp;
-
-  EXPECT_EQ("root2", root1.Version());
-  EXPECT_EQ("root1", root2.Version());
 }
 
 /////////////////////////////////////////////////
@@ -205,7 +165,7 @@ TEST(DOMRoot, Set)
 }
 
 /////////////////////////////////////////////////
-TEST(DOMRoot, FrameSemanticsOnCopyAndMove)
+TEST(DOMRoot, FrameSemanticsOnMove)
 {
   const std::string sdfString1 = R"(
     <sdf version="1.8">
@@ -263,33 +223,6 @@ TEST(DOMRoot, FrameSemanticsOnCopyAndMove)
     sdf::Errors errors = root2.LoadSdfString(sdfString2);
     EXPECT_TRUE(errors.empty()) << errors;
     testFrame2(root2);
-  }
-
-  {
-    sdf::Root root1;
-    sdf::Errors errors = root1.LoadSdfString(sdfString1);
-    EXPECT_TRUE(errors.empty()) << errors;
-    // root2 is copy constructed from root1
-    sdf::Root root2(root1);
-    testFrame1(root1);
-    testFrame1(root2);
-  }
-
-  {
-    sdf::Root root1;
-    sdf::Errors errors = root1.LoadSdfString(sdfString1);
-    EXPECT_TRUE(errors.empty()) << errors;
-    sdf::Root root2;
-    errors = root2.LoadSdfString(sdfString2);
-    EXPECT_TRUE(errors.empty()) << errors;
-
-    testFrame1(root1);
-    testFrame2(root2);
-
-    // root1 is copied into root2 via the assignment operator
-    root2 = root1;
-    testFrame1(root1);
-    testFrame1(root2);
   }
 
   {

--- a/src/Root_TEST.cc
+++ b/src/Root_TEST.cc
@@ -283,6 +283,9 @@ TEST(DOMRoot, FrameSemanticsOnCopyAndMove)
     errors = root2.LoadSdfString(sdfString2);
     EXPECT_TRUE(errors.empty()) << errors;
 
+    testFrame1(root1);
+    testFrame2(root2);
+
     // root1 is copied into root2 via the assignment operator
     root2 = root1;
     testFrame1(root1);
@@ -306,6 +309,9 @@ TEST(DOMRoot, FrameSemanticsOnCopyAndMove)
     sdf::Root root2;
     errors = root2.LoadSdfString(sdfString2);
     EXPECT_TRUE(errors.empty()) << errors;
+
+    testFrame1(root1);
+    testFrame2(root2);
 
     // root1 is moved into root2 via the move assignment operator.
     root2 = std::move(root1);

--- a/src/ScopedGraph.hh
+++ b/src/ScopedGraph.hh
@@ -123,6 +123,11 @@ class ScopedGraph
   /// passed in graph.
   /// \param[in] _graph A shared pointer to PoseRelativeTo or FrameAttachedTo
   /// graph.
+  /// \remark The state of the ScopedGraph after construction is invalid because
+  /// member variables such as "ScopedGraphData::prefix" and
+  /// "ScopedGraphData::scopeName" will be empty. Therefore, it is imperative
+  /// that this constructor should only be used right before calling either
+  /// buildPoseRelativeToGraph or buildFrameAttachedToGraph.
   public: explicit ScopedGraph(const std::shared_ptr<T> &_graph);
 
   /// \brief Creates a scope anchored at an existing child model vertex.

--- a/src/World.cc
+++ b/src/World.cc
@@ -35,7 +35,7 @@ using namespace sdf;
 class sdf::WorldPrivate
 {
   /// \brief Default constructor
-  public: WorldPrivate();
+  public: WorldPrivate() = default;
 
   /// \brief Copy constructor
   /// \param[in] _worldPrivate Joint axis to move.
@@ -89,29 +89,14 @@ class sdf::WorldPrivate
   public: ignition::math::Vector3d windLinearVelocity =
            ignition::math::Vector3d::Zero;
 
-  /// \brief Frame Attached-To Graph constructed during Load.
-  public: std::shared_ptr<sdf::FrameAttachedToGraph> ownedFrameAttachedToGraph;
-
   /// \brief Scoped Frame Attached-To graph that points to a graph owned
   /// by this world.
   public: sdf::ScopedGraph<sdf::FrameAttachedToGraph> frameAttachedToGraph;
-
-  /// \brief Pose Relative-To Graph constructed during Load.
-  public: std::shared_ptr<sdf::PoseRelativeToGraph> ownedPoseRelativeToGraph;
 
   /// \brief Scoped Pose Relative-To graph that points to a graph owned by this
   /// world.
   public: sdf::ScopedGraph<sdf::PoseRelativeToGraph> poseRelativeToGraph;
 };
-
-/////////////////////////////////////////////////
-WorldPrivate::WorldPrivate()
-    : ownedFrameAttachedToGraph(std::make_shared<sdf::FrameAttachedToGraph>())
-    , frameAttachedToGraph(ownedFrameAttachedToGraph)
-    , ownedPoseRelativeToGraph(std::make_shared<sdf::PoseRelativeToGraph>())
-    , poseRelativeToGraph(ownedPoseRelativeToGraph)
-{
-}
 
 /////////////////////////////////////////////////
 WorldPrivate::WorldPrivate(const WorldPrivate &_worldPrivate)
@@ -135,19 +120,6 @@ WorldPrivate::WorldPrivate(const WorldPrivate &_worldPrivate)
   if (_worldPrivate.gui)
   {
     this->gui = std::make_unique<Gui>(*(_worldPrivate.gui));
-  }
-  if (_worldPrivate.ownedFrameAttachedToGraph)
-  {
-    this->ownedFrameAttachedToGraph =
-        std::make_shared<sdf::FrameAttachedToGraph>(
-            *(_worldPrivate.ownedFrameAttachedToGraph));
-    this->frameAttachedToGraph = ScopedGraph(this->ownedFrameAttachedToGraph);
-  }
-  if (_worldPrivate.ownedPoseRelativeToGraph)
-  {
-    this->ownedPoseRelativeToGraph = std::make_shared<sdf::PoseRelativeToGraph>(
-        *(_worldPrivate.ownedPoseRelativeToGraph));
-    this->poseRelativeToGraph = ScopedGraph(this->ownedPoseRelativeToGraph);
   }
   if (_worldPrivate.scene)
   {
@@ -360,43 +332,6 @@ Errors World::Load(sdf::ElementPtr _sdf)
     Errors sceneLoadErrors =
         this->dataPtr->scene->Load(_sdf->GetElement("scene"));
     errors.insert(errors.end(), sceneLoadErrors.begin(), sceneLoadErrors.end());
-  }
-
-  // Build the graphs.
-  Errors frameAttachedToGraphErrors =
-  buildFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph, this);
-  errors.insert(errors.end(), frameAttachedToGraphErrors.begin(),
-                              frameAttachedToGraphErrors.end());
-  Errors validateFrameAttachedGraphErrors =
-    validateFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
-  errors.insert(errors.end(), validateFrameAttachedGraphErrors.begin(),
-                              validateFrameAttachedGraphErrors.end());
-  for (auto &frame : this->dataPtr->frames)
-  {
-    frame.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
-  }
-
-  Errors poseRelativeToGraphErrors =
-  buildPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph, this);
-  errors.insert(errors.end(), poseRelativeToGraphErrors.begin(),
-                              poseRelativeToGraphErrors.end());
-  Errors validatePoseGraphErrors =
-    validatePoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
-  errors.insert(errors.end(), validatePoseGraphErrors.begin(),
-                              validatePoseGraphErrors.end());
-  for (auto &frame : this->dataPtr->frames)
-  {
-    frame.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
-  }
-  for (auto &model : this->dataPtr->models)
-  {
-    model.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
-    model.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
-  }
-  for (auto &light : this->dataPtr->lights)
-  {
-    light.SetXmlParentName("world");
-    light.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
   }
 
   return errors;
@@ -681,4 +616,40 @@ bool World::PhysicsNameExists(const std::string &_name) const
   }
 
   return false;
+}
+
+/////////////////////////////////////////////////
+void World::SetPoseRelativeToGraph(sdf::ScopedGraph<PoseRelativeToGraph> _graph)
+{
+  this->dataPtr->poseRelativeToGraph = _graph;
+
+  for (auto &model : this->dataPtr->models)
+  {
+    model.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
+  }
+  for (auto &frame : this->dataPtr->frames)
+  {
+    frame.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
+  }
+  for (auto &light : this->dataPtr->lights)
+  {
+    light.SetXmlParentName("world");
+    light.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
+  }
+}
+
+/////////////////////////////////////////////////
+void World::SetFrameAttachedToGraph(
+    sdf::ScopedGraph<FrameAttachedToGraph> _graph)
+{
+  this->dataPtr->frameAttachedToGraph = _graph;
+
+  for (auto &frame : this->dataPtr->frames)
+  {
+    frame.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
+  }
+  for (auto &model : this->dataPtr->models)
+  {
+    model.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
+  }
 }

--- a/src/World.cc
+++ b/src/World.cc
@@ -110,7 +110,9 @@ WorldPrivate::WorldPrivate(const WorldPrivate &_worldPrivate)
       name(_worldPrivate.name),
       physics(_worldPrivate.physics),
       sdf(_worldPrivate.sdf),
-      windLinearVelocity(_worldPrivate.windLinearVelocity)
+      windLinearVelocity(_worldPrivate.windLinearVelocity),
+      frameAttachedToGraph(_worldPrivate.frameAttachedToGraph),
+      poseRelativeToGraph(_worldPrivate.poseRelativeToGraph)
 {
   if (_worldPrivate.atmosphere)
   {
@@ -145,20 +147,6 @@ World::~World()
 World::World(const World &_world)
   : dataPtr(new WorldPrivate(*_world.dataPtr))
 {
-  for (auto &frame : this->dataPtr->frames)
-  {
-    frame.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
-    frame.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
-  }
-  for (auto &model : this->dataPtr->models)
-  {
-    model.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
-  }
-  for (auto &light : this->dataPtr->lights)
-  {
-    light.SetXmlParentName("world");
-    light.SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
-  }
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
This builds on top of #381 and simplifies the creation of PoseRelativeTo and FrameAttachedTo graphs by moving them to one place instead of being in `sdf::World` and `sdf::Model`. It also simplifies the logic of determining if a model is a standalone model that needs its own graph or a nested model that adds to an existing graph. 

This PR also changes the pointer held by ScopedGraph from a `std::weak_ptr` to a `std::shared_ptr`. This means that a DOM object, such as `sdf::Model`, can have its poses resolved even if the containing `sdf::Root` or `sdf::World` has gone out of scope.

A couple more notes:

* When copying any DOM object with the exception of `sdf::Root`, there is no need to call `SetPoseRelativeToGraph` or `SetFrameAttachedToGraph`on child elements because the copy constructors of those child elements copy the `ScopedGraph` from the corresponding child element from the copied-from object. Since a new graph is never created, the child elements should be pointing to the graph of the copied-from object when their copy constructor is finished.

* When copying from sdf::Root, we have to decide whether we want a deep copy of the graph or not. If we do a shallow copy, the constructor that simply copies the `dataPtr` is sufficient. Otherwise, we have to allocate new memory, make a copy of the graph and call `SetPoseRelativeToGraph` and `SetFrameAttachedToGraph` on all child elements of `sdf::Root`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azeey/sdformat/1)
<!-- Reviewable:end -->
